### PR TITLE
Fix syntax in encrypted.py

### DIFF
--- a/lib/python/xxdiff/scripts/encrypted.py
+++ b/lib/python/xxdiff/scripts/encrypted.py
@@ -57,6 +57,8 @@ encrypted or not:
 
 """
 
+from __future__ import print_function
+
 __moredoc__ = """
 Safety Notes
 ------------
@@ -76,8 +78,6 @@ calculate the diffs internally.
 the diffs (e.g. modifying an unsuspecting user's resources in ~/.xxdiffrc), they
 could feed the decrypted files to an arbitrary program.)
 """
-
-from __future__ import print_function
 
 __author__ = "Martin Blais <blais@furius.ca>"
 __depends__ = ['xxdiff', 'Python-2.4', 'GnuPG']


### PR DESCRIPTION
Fixes the following issue 

$ python -m py_compile  encrypted.py 
  File "encrypted.py", line 80
    from __future__ import print_function
    ^
SyntaxError: from __future__ imports must occur at the beginning of the file